### PR TITLE
Make dev server work with centralized db server setup

### DIFF
--- a/config/localdev-db-config.yaml
+++ b/config/localdev-db-config.yaml
@@ -1,0 +1,4 @@
+host: localhost
+user: wikilabels
+database: wikilabels
+password: wikilabels-admin

--- a/config/wikilabels-localdev.yaml
+++ b/config/wikilabels-localdev.yaml
@@ -7,10 +7,7 @@ wsgi:
   url_prefix: "/labels"
 
 database:
-  host: localhost
-  user: wikilabels
-  database: wikilabels
-  password: wikilabels-admin
+  config: config/localdev-db-config.yaml
 
 oauth:
   mw_uri: https://www.mediawiki.org/w/index.php

--- a/wikilabels/utilities/dev_server.py
+++ b/wikilabels/utilities/dev_server.py
@@ -26,6 +26,9 @@ def main(argv=None):
 
     if args['--config'] is not None:
         config = yamlconf.load(open(args['--config']))
+        # FIXME: DON'T DO THIS
+        db_config = config['database']['config']
+        config['database'] = yamlconf.load(open(db_config))
     else:
         config = None
 


### PR DESCRIPTION
After moving db server config to separate file to support the
centralized postgres server setup, loading config for db as is fails.
This commit has a hack to work around that. MUST FIX.