### PR TITLE
Fix SSL bug

### DIFF
--- a/wikilabels/wsgi/routes/form_builder.py
+++ b/wikilabels/wsgi/routes/form_builder.py
@@ -4,7 +4,7 @@ from flask import Response, render_template, request, send_from_directory
 from ..util import (build_script_tags, build_style_tags, read_cat,
                     read_javascript)
 
-TOOLS_CDN = "//tools-static.wmflabs.org/cdnjs/ajax/libs/"
+TOOLS_CDN = "https://tools-static.wmflabs.org/cdnjs/ajax/libs/"
 
 MEDIAWIKI_LIBS = ("lib/mediaWiki/mediaWiki.js",
                   TOOLS_CDN + "jquery/2.1.3/jquery.js",


### PR DESCRIPTION
If you click on http://labels.wmflabs.org/form_builder/FormBuilder.js

It returns 502 error, running it in localhost showed me that
the bug is when we want to load from tools CDN. it returns
"File not found" error. It fixed it in my localhost :)