### PR TITLE
Correct alignment for RTL wikis

### DIFF
--- a/wikilabels/wsgi/static/css/form.css
+++ b/wikilabels/wsgi/static/css/form.css
@@ -11,6 +11,13 @@
 .wikilabels-form .fieldset > .oo-ui-fieldsetLayout > div > * {
   text-align: left;
 }
+/*
+Fix for RTL sites.
+This can be removed if this file is loaded using ResourceLoader and CSSJanus.
+*/
+.mw-content-rtl .wikilabels-form .fieldset > .oo-ui-fieldsetLayout > div > * {
+  text-align: right;
+}
 
 .wikilabels-form .inline-field {
   display: inline-block;

--- a/wikilabels/wsgi/static/css/views.css
+++ b/wikilabels/wsgi/static/css/views.css
@@ -17,6 +17,13 @@
 .wikilabels-diff-to-previous > .error {
   text-align: left;
 }
+/*
+Fix for RTL sites.
+This can be removed if this file is loaded using ResourceLoader and CSSJanus.
+*/
+.mw-content-rtl .wikilabels-diff-to-previous > .error {
+  text-align: right;
+}
 .wikilabels-diff-to-previous > .title {
   font-size: 150%;
   margin-top: 1em;
@@ -36,6 +43,13 @@
 .wikilabels-diff-to-previous > .diff {
   text-align: left;
   margin-top: 1em;
+}
+/*
+Fix for RTL sites.
+This can be removed if this file is loaded using ResourceLoader and CSSJanus.
+*/
+.mw-content-rtl .wikilabels-diff-to-previous > .diff {
+  text-align: right;
 }
 .wikilabels-diff-to-previous > .no-difference {
   font-size: 200%;


### PR DESCRIPTION
Diffs and tooltips are force-aligned to the left, so it looks weird
in RTL wikis. This patch fixes it.
If WikiLabels was loaded using ResourceLoader and CSSJanus,
this wouldn't be needed, but currently CSSJanus is not applied,
so these hacks are needed.
I tested this in the Hebrew Wikipedia and it works.