### PR TITLE
Rephrase the "not completed" message

### DIFF
--- a/wikilabels/i18n/en.json
+++ b/wikilabels/i18n/en.json
@@ -1,6 +1,6 @@
 {
 	"@metadata": [],
-	"'$1' not completed.  Submit anyway?": "'$1' not completed.  Submit anyway?",
+	"'$1' not completed.  Submit anyway?": "The field \"$1\" was not filled.  Submit anyway?",
 	"Abandon": "Abandon",
 	"Are you sure that you want to abandon this task?": "Are you sure that you want to abandon this task?",
 	"Campaigns": "Campaigns",

--- a/wikilabels/i18n/qqq.json
+++ b/wikilabels/i18n/qqq.json
@@ -7,7 +7,7 @@
 			"Tgr"
 		]
 	},
-	"'$1' not completed.  Submit anyway?": "When the user tries to send a workset that is not completed yet.",
+	"'$1' not completed.  Submit anyway?": "When the user tries to send an assessment of a diff in which not all form fields were filled. $1 is the name of the field, such as \"Damaging\" or \"Good faith\".",
 	"Abandon": "{{Identical|Abandon}}",
 	"Campaigns": "This is the header for a list of \"campaigns\".  Campaigns in WikiLabels are collections of items to be annotated.\n{{Identical|Campaign}}",
 	"Diff for revision $1": "This message is showed above an edit diff.  The $1 will be replaced with a link to the MediaWiki Special:Diff interface. The text of the link is a number (the revision ID).",


### PR DESCRIPTION
This message is about a field, rather than about a whole workset,
so rephrase it accordingly.
Update the qqq documentation accordingly.