### PR TITLE
Remove README instruction to install JS dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ Copy-paste config/schema.sql into the command prompt.
 
 Optionally, you can also load sample data into the database by copy-pasting config/schema-testdata.sql into the command prompt
 
-### Installing javascript dependencies
-
-    $ npm install codemirror jquery oojs oojs-ui strftime yamljs
-
 ### Starting the dev server
 
     $ wikilabels dev_server --config config-localdev.yaml


### PR DESCRIPTION
They are not actually loaded through npm at all,
they're all embedded in the lib/ directory.