### PR TITLE
/ui/ path

### DIFF
--- a/config/00-main.yaml
+++ b/config/00-main.yaml
@@ -13,3 +13,14 @@ database:
 
 oauth:
   mw_uri: https://www.mediawiki.org/w/index.php
+
+wikis:
+  testwiki:
+    db_name: 'testwiki'
+    wiki_path: 'test.wikipedia.org'
+    lang_code: 'en'
+  fawiki:
+    db_name: 'fawiki'
+    wiki_path: 'fa.wikipedia.org'
+    lang_code: 'fa'
+    dir: rtl

--- a/wikilabels/wsgi/routes/__init__.py
+++ b/wikilabels/wsgi/routes/__init__.py
@@ -4,6 +4,7 @@ from . import form_builder
 from . import forms
 from . import gadget
 from . import users
+from . import ui
 
 
 def configure(config, bp, db, oauth, form_map):
@@ -20,5 +21,6 @@ def configure(config, bp, db, oauth, form_map):
     bp = forms.configure(bp, config, form_map)
     bp = form_builder.configure(bp, config)
     bp = gadget.configure(bp, config)
+    bp = ui.configure(bp, config)
 
     return bp

--- a/wikilabels/wsgi/routes/__init__.py
+++ b/wikilabels/wsgi/routes/__init__.py
@@ -1,3 +1,5 @@
+from flask import render_template
+
 from . import auth
 from . import campaigns
 from . import form_builder
@@ -11,9 +13,7 @@ def configure(config, bp, db, oauth, form_map):
 
     @bp.route("/")
     def index():
-        return "Welcome to the index page of the Wiki labels flask app. " + \
-               "There are 5 top-level paths: auth, campaigns, users, " + \
-               "forms and form_builder."
+        return render_template("home.html")
 
     bp = auth.configure(bp, config, oauth)
     bp = campaigns.configure(bp, config, db)

--- a/wikilabels/wsgi/routes/gadget.py
+++ b/wikilabels/wsgi/routes/gadget.py
@@ -1,8 +1,9 @@
 from flask import Response, render_template, request, send_from_directory
 
+from .. import responses
 from ..util import (app_path, build_script_tags, build_style_tags, i18n_dict,
                     minify_js, pretty_json, read_cat, static_file_path,
-                    url_for, get_wiki_config)
+                    url_for)
 
 TOOLS_CDN = "//tools-static.wmflabs.org/cdnjs/ajax/libs/"
 
@@ -45,9 +46,10 @@ CSS = ("css/oo.ui.SemanticOperationsSelector.css",
 def configure(bp, config):
     @bp.route("/gadget/")
     def gadget():
-        enwiki_lib = ["lib/mediaWiki/mediaWiki.js"]
-        script_tags = build_script_tags(enwiki_lib + MEDIAWIKI_LIBS + LOCAL_LIBS + JS,
-                                        config)
+        enwiki_lib = tuple(["lib/mediaWiki/mediaWiki.js"])
+        script_tags = build_script_tags(
+            enwiki_lib + MEDIAWIKI_LIBS + LOCAL_LIBS + JS,
+            config)
         script_tags += '<script src="{0}"></script>' \
                        .format(app_path('/gadget/WikiLabels.messages.js',
                                         config))
@@ -103,10 +105,9 @@ def configure(bp, config):
 
     @bp.route("/gadget/<wiki>/mediawiki.js")
     def gadget_wiki(wiki):
-        wiki_config = get_wiki_config(wiki)
-        if not wiki_config:
+        if wiki not in config['wikis']:
             return responses.not_found('Wiki config not found')
-        js = render_template("mediawiki.js", **wiki_config)
+        js = render_template("mediawiki.js", **config['wikis'][wiki])
         return Response(js, mimetype="application/javascript")
 
     return bp

--- a/wikilabels/wsgi/routes/ui.py
+++ b/wikilabels/wsgi/routes/ui.py
@@ -1,41 +1,37 @@
-from flask import Response, render_template, request, send_from_directory
+from flask import render_template
 
-from ..util import (app_path, build_script_tags, build_style_tags, i18n_dict,
-                    minify_js, pretty_json, read_cat, static_file_path,
-                    url_for)
-from .gadget import TOOLS_CDN, LOCAL_LIBS, JS, MEDIAWIKI_STYLES, CSS, LOCAL_STYLES
-
-MEDIAWIKI_LIBS = (TOOLS_CDN + "jquery/2.1.3/jquery.js",
-                  "lib/jquery-spinner/jquery.spinner.js",
-                  "/oojs-static/oojs.jquery.js",
-                  "/oojs-ui-static/oojs-ui.js",
-                  "/oojs-ui-static/oojs-ui-mediawiki.js")
+from .. import responses
+from ..util import app_path, build_script_tags, build_style_tags, url_for
+from .gadget import (MEDIAWIKI_LIBS, LOCAL_LIBS, JS, MEDIAWIKI_STYLES, CSS,
+                     LOCAL_STYLES)
 
 
 def configure(bp, config):
+
     @bp.route("/ui/")
     def ui():
-        # TODO: List avalible wikis
-        return "Welcome to the index page of the Wiki labels flask app. " + \
-               "There are 5 top-level paths: auth, campaigns, users, " + \
-               "forms and form_builder."
+        return render_template("ui.html",
+                               wikis=sorted(list(config['wikis'].keys())))
 
     @bp.route("/ui/<wiki>")
     def standalone_ui(wiki):
+        if wiki not in config['wikis']:
+            return responses.not_found('Wiki config not found')
         script_tags = '<script src="{0}"></script>' \
-                       .format(app_path('/gadget/' + wiki + '/mediawiki.js',
-                                        config))
+            .format(app_path('/gadget/' + wiki + '/mediawiki.js',
+                    config))
         script_tags += build_script_tags(MEDIAWIKI_LIBS + LOCAL_LIBS + JS,
-                                        config)
+                                         config)
         script_tags += '<script src="{0}"></script>' \
                        .format(app_path('/gadget/WikiLabels.messages.js',
                                         config))
 
         style_tags = build_style_tags(MEDIAWIKI_STYLES + LOCAL_STYLES + CSS,
                                       config)
-        return render_template("gadget.html",
+        return render_template("ui_wiki.html",
                                script_tags=script_tags,
                                style_tags=style_tags,
-                               server_root=url_for("", config))
+                               server_root=url_for("", config),
+                               **config['wikis'][wiki])
 
     return bp

--- a/wikilabels/wsgi/routes/ui.py
+++ b/wikilabels/wsgi/routes/ui.py
@@ -1,0 +1,41 @@
+from flask import Response, render_template, request, send_from_directory
+
+from ..util import (app_path, build_script_tags, build_style_tags, i18n_dict,
+                    minify_js, pretty_json, read_cat, static_file_path,
+                    url_for)
+from .gadget import TOOLS_CDN, LOCAL_LIBS, JS, MEDIAWIKI_STYLES, CSS, LOCAL_STYLES
+
+MEDIAWIKI_LIBS = (TOOLS_CDN + "jquery/2.1.3/jquery.js",
+                  "lib/jquery-spinner/jquery.spinner.js",
+                  "/oojs-static/oojs.jquery.js",
+                  "/oojs-ui-static/oojs-ui.js",
+                  "/oojs-ui-static/oojs-ui-mediawiki.js")
+
+
+def configure(bp, config):
+    @bp.route("/ui/")
+    def ui():
+        # TODO: List avalible wikis
+        return "Welcome to the index page of the Wiki labels flask app. " + \
+               "There are 5 top-level paths: auth, campaigns, users, " + \
+               "forms and form_builder."
+
+    @bp.route("/ui/<wiki>")
+    def standalone_ui(wiki):
+        script_tags = '<script src="{0}"></script>' \
+                       .format(app_path('/gadget/' + wiki + '/mediawiki.js',
+                                        config))
+        script_tags += build_script_tags(MEDIAWIKI_LIBS + LOCAL_LIBS + JS,
+                                        config)
+        script_tags += '<script src="{0}"></script>' \
+                       .format(app_path('/gadget/WikiLabels.messages.js',
+                                        config))
+
+        style_tags = build_style_tags(MEDIAWIKI_STYLES + LOCAL_STYLES + CSS,
+                                      config)
+        return render_template("gadget.html",
+                               script_tags=script_tags,
+                               style_tags=style_tags,
+                               server_root=url_for("", config))
+
+    return bp

--- a/wikilabels/wsgi/templates/home.html
+++ b/wikilabels/wsgi/templates/home.html
@@ -1,0 +1,73 @@
+<html lang="en" dir="ltr" class="client-js ve-not-available">
+  <head>
+    <title>Labels home gadget</title>
+    <link rel="stylesheet" type="text/css" href="/oojs-ui-static/oojs-ui-mediawiki.css" />
+    <link rel="stylesheet" type="text/css" href="/static/lib/mediaWiki/enwiki.vector.css" />
+    <link rel="stylesheet" type="text/css" href="/static/lib/mediaWiki/enwiki.common.css" />
+    <style>
+      body {
+        background: #fff;
+        margin: 0px 2em;
+      }
+    </style>
+  </head>
+  <body class="mediawiki ltr sitedir-ltr ns-4 ns-subject page-Wikipedia_Labels
+               skin-vector action-view webfonts-changed">
+    <style type="text/css">
+    html {
+      background: #eaecf0;
+    }
+    body {
+      max-width: 50em;
+      margin: 0px auto;
+      padding: 1em 2em;
+      background: #fff;
+    }
+    </style>
+    <div id="bodyContent" class="mw-body-content">
+      <div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr">
+        <div id="wikilabels-home">
+          <div class="lead">
+            <p>
+                <strong class="selflink">Wiki-Labels</strong> is a
+                <a href="https://en.wikipedia.org/wiki/Human_computation"
+                   title="Human computation"
+                   class="mw-redirect">human computation</a>
+                service for Wikipedia. In order perform difficult analyses and
+                train intelligent wiki-tools (e.g. for
+                <a href="https://meta.wikimedia.org/wiki/Objective_Revision_Evaluation_Service#Edit_quality_models">detecting vandalism</a> and
+                <a href="https://meta.wikimedia.org/wiki/Objective_Revision_Evaluation_Service#Article_quality_models">
+                  assessing the quality of articles
+                </a>), we need
+                <a href="https://en.wikipedia.org/wiki/Coding_(social_sciences)"
+                   title="Coding (social sciences)">labeled data</a>
+                and lots of it. Wiki-Labels is a tool that makes it easy to
+                collaboratively label wiki artifacts (like revisions) quickly
+                and easily.
+            </p>
+              You can start labeling edits in <a href="/ui/">here</a>.
+              <p>
+              <p>
+              Other top-level paths: <a href="/auth/">auth</a>, <a href="/campaigns/">campaigns</a>, <a href="/users/">users</a>, <a href="/forms/">forms</a> and <a href="/form_builder/">form_builder</a>
+          </p>
+            <ul>
+              <li>
+                <a href="https://en.wikipedia.org/wiki/Wikipedia:Labels/Documentation"
+                   title="Wikipedia:Labels/Documentation"
+                   class="mw-redirect">
+                  Documentation
+                </a>
+              </li>
+              <li>
+                <a rel="nofollow" class="external text"
+                   href="https://github.com/wiki-ai/wikilabels">
+                  github repo
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/wikilabels/wsgi/templates/mediawiki.js
+++ b/wikilabels/wsgi/templates/mediawiki.js
@@ -6,11 +6,11 @@
 
 	var Config = function () {
 		this.obj = {
-		'wgDBname': 'enwiki',
-		'wgServer': '//en.wikipedia.org',
+		'wgDBname': '{{ db_name|safe }}',
+		'wgServer': '//{{ wiki_path|safe }}',
 		'wgArticlePath': '/wiki/$1',
 		'wgScriptPath': '/w',
-		'wgUserLanguage': 'en'
+		'wgUserLanguage': '{{ lang_code|safe }}'
 		};
 	};
 	Config.prototype.get = function(key){
@@ -19,7 +19,7 @@
 
 	var util = {
 		wikiScript: function(){return "/w/api.php";},
-		getUrl: function(title){return "//en.wikipedia.org/wiki/" + title;}
+		getUrl: function(title){return "//{{ wiki_path|safe }}/wiki/" + title;}
 	};
 
 	window.mediaWiki = {
@@ -27,6 +27,6 @@
 		msg: function (key) {throw 'msg not implemented';},
 		config: new Config(),
 		util: util,
-		language: {getFallbackLanguageChain: function(){return ['en', 'pt'];}}
+		language: {getFallbackLanguageChain: function(){return ['{{ lang_code|safe }}', 'en'];}}
 	};
 })();

--- a/wikilabels/wsgi/templates/ui.html
+++ b/wikilabels/wsgi/templates/ui.html
@@ -1,0 +1,42 @@
+<html lang="en" dir="ltr" class="client-js ve-not-available">
+  <head>
+    <title>Labels home gadget</title>
+    <link rel="stylesheet" type="text/css" href="/oojs-ui-static/oojs-ui-mediawiki.css" />
+    <link rel="stylesheet" type="text/css" href="/static/lib/mediaWiki/enwiki.vector.css" />
+    <link rel="stylesheet" type="text/css" href="/static/lib/mediaWiki/enwiki.common.css" />
+    <style>
+      body {
+        background: #fff;
+        margin: 0px 2em;
+      }
+    </style>
+  </head>
+  <body class="mediawiki ltr sitedir-ltr ns-4 ns-subject page-Wikipedia_Labels
+               skin-vector action-view webfonts-changed">
+    <style type="text/css">
+    html {
+      background: #eaecf0;
+    }
+    body {
+      max-width: 50em;
+      margin: 0px auto;
+      padding: 1em 2em;
+      background: #fff;
+    }
+    </style>
+    <div id="bodyContent" class="mw-body-content">
+      <div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr">
+        <div id="wikilabels-home">
+          <div class="lead">
+                <h2>Avalible wikis</h2>
+                <ul>
+               {% for wiki in wikis %}
+                    <li><a href="/ui/{{ wiki }}">{{ wiki }}</a></li>
+               {% endfor %}
+                </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/wikilabels/wsgi/templates/ui_wiki.html
+++ b/wikilabels/wsgi/templates/ui_wiki.html
@@ -1,0 +1,52 @@
+<html lang="{{ lang_code|safe }}" dir="{{ dir if dir != None else 'ltr' }}" class="client-js ve-not-available">
+  <head>
+    <title>Labels home gadget</title>
+    <link rel="stylesheet" type="text/css" href="https://{{ wiki_path|safe }}/w/index.php?title=MediaWiki:Common.css&action=raw&ctype=text/css" />
+    <link rel="stylesheet" type="text/css" href="https://{{ wiki_path|safe }}/w/index.php?title=MediaWiki:Vector.css&action=raw&ctype=text/css" />
+    {{ script_tags|safe }}
+    {{ style_tags|safe }}
+    <style>
+      body {
+        background: #fff;
+        margin: 0px 2em;
+      }
+    </style>
+  </head>
+  <body class="mediawiki ltr sitedir-ltr ns-4 ns-subject page-Wikipedia_Labels
+               skin-vector action-view webfonts-changed">
+    <style type="text/css">
+    html {
+      background: #eaecf0;
+    }
+    body {
+      max-width: 50em;
+      margin: 0px auto;
+      padding: 1em 2em;
+      background: #fff;
+    }
+    </style>
+    <div id="bodyContent" class="mw-body-content">
+      <div id="mw-content-text" lang="{{ lang_code|safe }}" dir="{{ dir if dir != None else 'ltr' }}" class="mw-content-{{ dir if dir != None else 'ltr' }}">
+        <div id="wikilabels-home">
+          <div class="lead">
+               <!-- Fill this later -->
+          </div>
+          <div class="wikilabels-menu"
+               style=" ">
+            <div style="padding-top: 2em;">
+              <span style="font-size: 200%;">Please enable javascript, otherwise it doesn't work</span>
+            </div>
+          </div>
+          <div class="wikilabels-workspace" style="clear:both;">
+          </div>
+        </div>
+        <script>
+          wikiLabels.config.update( {
+            serverRoot: '{{ server_root|safe }}'
+          } );
+          home = new wikiLabels.Home($('#wikilabels-home'));
+        </script>
+      </div>
+    </div>
+  </body>
+</html>

--- a/wikilabels/wsgi/util.py
+++ b/wikilabels/wsgi/util.py
@@ -10,6 +10,19 @@ from flask import current_app, request
 from .responses import bad_request
 
 
+wiki_data = {
+    'enwiki': {
+        'db_name': 'enwiki',
+        'wiki_path': 'en.wikipedia.org',
+        'lang_code': 'en'
+    },
+    'fawiki': {
+        'db_name': 'fawiki',
+        'wiki_path': 'fa.wikipedia.org',
+        'lang_code': 'fa'
+    },
+}
+
 class ParamError(Exception):
     pass
 
@@ -135,3 +148,8 @@ def i18n_dict():
 def pretty_json(data):
     return json.dumps(data, ensure_ascii=False, sort_keys=True,
                       separators=(',', ': '), indent=8)
+
+def get_wiki_config(wiki):
+    if wiki not in wiki_data:
+        return None
+    return wiki_data[wiki]

--- a/wikilabels/wsgi/util.py
+++ b/wikilabels/wsgi/util.py
@@ -10,19 +10,6 @@ from flask import current_app, request
 from .responses import bad_request
 
 
-wiki_data = {
-    'enwiki': {
-        'db_name': 'enwiki',
-        'wiki_path': 'en.wikipedia.org',
-        'lang_code': 'en'
-    },
-    'fawiki': {
-        'db_name': 'fawiki',
-        'wiki_path': 'fa.wikipedia.org',
-        'lang_code': 'fa'
-    },
-}
-
 class ParamError(Exception):
     pass
 
@@ -148,8 +135,3 @@ def i18n_dict():
 def pretty_json(data):
     return json.dumps(data, ensure_ascii=False, sort_keys=True,
                       separators=(',', ': '), indent=8)
-
-def get_wiki_config(wiki):
-    if wiki not in wiki_data:
-        return None
-    return wiki_data[wiki]


### PR DESCRIPTION
Stuff already done:
 - /ui/wiki/ now works and changes config to the point out to correct API endpoint 

Stuff to be done:
 - Move config to a better place
 - Have common.css and common.js being loaded per-wiki
 - /ui/ itself should have better interface
 - The root path ("/") should be better
 - gadget.html should have per-language description
 - minification for performance
 - Reducing number of requests as much as possible