### PR TITLE
Bring back i18n in form builder

### DIFF
--- a/wikilabels/wsgi/templates/form_builder.html
+++ b/wikilabels/wsgi/templates/form_builder.html
@@ -61,6 +61,17 @@ fields:
       name: "notes"
       class: "TextInputWidget"
       multiline: true
+
+i18n:
+  en:
+    form-title: Edit quality
+    notes-label: "Notes"
+    damaging-label: "Damaging?"
+    damaging-true-label: "yes"
+    damaging-false-label: "no"
+    goodfaith-label: "Good-faith?"
+    goodfaith-true-label: "yes"
+    goodfaith-false-label: "no"
 </textarea>
     <script>
       var formBuilder = new wikiLabels.FormBuilder()


### PR DESCRIPTION
Right now the language is empty casuing the whole form_builder to fail