### PR TITLE
Add info_url column in campaign table

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,7 +2,6 @@
 	"extends": "./node_modules/stylelint-config-wikimedia",
 	"rules": {
 		"no-descending-specificity": null,
-		"declaration-no-important": null,
-		"selector-no-id": null
+		"declaration-no-important": null
 	}
 }

--- a/wikilabels/database/campaigns.py
+++ b/wikilabels/database/campaigns.py
@@ -4,7 +4,7 @@ from .errors import NotFoundError
 
 class Campaigns(Collection):
     def create(self, wiki, name, form, view, labels_per_task,
-               tasks_per_assignment, active):
+               tasks_per_assignment, active, info_url):
         with self.db.transaction() as transactor:
             cursor = transactor.cursor()
             cursor.execute("""
@@ -18,6 +18,7 @@ class Campaigns(Collection):
                   'name': name,
                   'form': form,
                   'view': view,
+                  'info_url': info_url,
                   'labels_per_task': labels_per_task,
                   'tasks_per_assignment': tasks_per_assignment,
                   'active': active})
@@ -53,7 +54,8 @@ class Campaigns(Collection):
                     EXTRACT(EPOCH FROM campaign.created) AS created,
                     labels_per_task,
                     tasks_per_assignment,
-                    active
+                    active,
+                    campaign.info_url
                 FROM campaign
                 WHERE id = %(campaign_id)s;
             """, {'campaign_id': campaign_id})
@@ -123,7 +125,8 @@ class Campaigns(Collection):
                     EXTRACT(EPOCH FROM campaign.created) AS created,
                     labels_per_task,
                     tasks_per_assignment,
-                    active
+                    active,
+                    campaign.info_url
                 FROM campaign
                 WHERE
                     wiki = %(wiki)s AND
@@ -151,7 +154,8 @@ class Campaigns(Collection):
                     EXTRACT(EPOCH FROM campaign.created) AS created,
                     labels_per_task,
                     tasks_per_assignment,
-                    active
+                    active,
+                    campaign.info_url,
                 FROM workset
                 INNER JOIN campaign ON campaign_id = campaign.id
                 WHERE user_id = %(user_id)s

--- a/wikilabels/database/patches/patch-campaign-add-info-column.sql
+++ b/wikilabels/database/patches/patch-campaign-add-info-column.sql
@@ -1,0 +1,9 @@
+DO $$
+    BEGIN
+        BEGIN
+           ALTER TABLE campaign ADD COLUMN info_url VARCHAR(2000);
+        EXCEPTION
+            WHEN duplicate_column THEN RAISE NOTICE 'column info_url already exists in campaign.';
+        END;
+    END;
+END$$

--- a/wikilabels/database/patches/patch-campaign-add-info-column.sql
+++ b/wikilabels/database/patches/patch-campaign-add-info-column.sql
@@ -1,9 +1,1 @@
-DO $$
-    BEGIN
-        BEGIN
-           ALTER TABLE campaign ADD COLUMN info_url VARCHAR(2000);
-        EXCEPTION
-            WHEN duplicate_column THEN RAISE NOTICE 'column info_url already exists in campaign.';
-        END;
-    END;
-END$$
+ALTER TABLE campaign ADD COLUMN info_url VARCHAR(2000);

--- a/wikilabels/database/schema.sql
+++ b/wikilabels/database/schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS campaign (
   wiki                 VARCHAR(255),
   form                 VARCHAR(255),
   view                 VARCHAR(255),
+  info_url             VARCHAR(2000),
   created              TIMESTAMP,
   labels_per_task      INT,
   tasks_per_assignment INT,

--- a/wikilabels/i18n/en.json
+++ b/wikilabels/i18n/en.json
@@ -26,5 +26,6 @@
 	"open": "open",
 	"request workset": "request workset",
 	"review": "review",
-	"maintenance notice": "Wiki labels is going down for maintenance on $1.  See $2 for more information."
+	"maintenance notice": "Wiki labels is going down for maintenance on $1.  See $2 for more information.",
+	"more-info": "(<a href=\"$1\">More info</a>)"
 }

--- a/wikilabels/wsgi/static/js/wikiLabels/Labeler.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/Labeler.js
@@ -168,6 +168,9 @@
 
 		this.$name = $( '<div>' ).addClass( 'name' );
 		this.$element.append( this.$name );
+		if ( campaignData.info_url ) {
+			this.$element.append( ' ' + WL.i18n( 'more-info', [ campaignData.info_url ] ) );
+		}
 
 		this.worksetList = new WorksetList();
 		this.$element.append( this.worksetList.$element );


### PR DESCRIPTION
Using the method that mediawiki uses for schema changes
Which means providing both new schema (for new installs) and
patches (for old installs), this is the safest way to handle schema change

Bug: T139957