### PR TITLE
Delete error codes in error messages and use absolute path

### DIFF
--- a/wikilabels/wsgi/routes/campaigns.py
+++ b/wikilabels/wsgi/routes/campaigns.py
@@ -84,7 +84,7 @@ def configure(bp, config, db):
             return responses.conflict(
                 str(e) +
                 " Please try again or check campaign status " +
-                url_for("wikilabels.stats_wiki", wiki=wiki))
+                url_for("wikilabels.stats_wiki", wiki=wiki, _external=True))
         except NotFoundError as e:
             return responses.not_found(str(e))
 

--- a/wikilabels/wsgi/static/js/wikiLabels/Labeler.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/Labeler.js
@@ -207,7 +207,7 @@
 				this.worksetActivated.fire( this, workset );
 			}.bind( this ) )
 			.fail( function ( doc ) {
-				alert( doc.code + ': ' + doc.message );
+				alert( doc.message );
 			} );
 	};
 	Campaign.prototype.updateButtonState = function () {


### PR DESCRIPTION
Delete error codes in error messages and use absolute path instead
of relative path in the error messages

Bug: T175726

fyi, I was able to reproduce this bug by adding some entries (in order to mark labels in the campaign as completed) to my dev database using this sql query (need to import `schema-testdata.sql` first):
```sql
TRUNCATE label;
INSERT INTO label VALUES
  (85, 608705, NOW(), '{"damaging": true, "good-faith": false}'),
  (86, 608705, NOW(), '{"damaging": false, "good-faith": true}'),
  (87, 608705, NOW(), '{"damaging": false, "good-faith": true}'),
  (84, 608705, NOW(), '{"damaging": false, "good-faith": true}'),
  (88, 608705, NOW(), '{"damaging": true, "good-faith": false}');
```
and open `ui/nlwiki/`