### PR TITLE
Add per-day stats for campaign

### DIFF
--- a/wikilabels/database/campaigns.py
+++ b/wikilabels/database/campaigns.py
@@ -199,3 +199,21 @@ class Campaigns(Collection):
             """.format(int(campaign_id)))
 
             return list(cursor)
+
+    def days(self, campaign_id):
+        with self.db.transaction() as transactor:
+            cursor = transactor.cursor()
+            cursor.execute("""
+                SELECT
+                to_char(date_trunc('day', label.timestamp), 'YYYY-MM-DD')
+                AS day,
+                COUNT(*) AS count
+                FROM label
+                JOIN workset_task ON label.task_id = workset_task.task_id
+                JOIN workset ON workset_task.workset_id = workset.id
+                WHERE campaign_id = {0}
+                GROUP BY day
+                ORDER BY day;
+            """.format(int(campaign_id)))
+
+            return list(cursor)

--- a/wikilabels/wsgi/routes/stats.py
+++ b/wikilabels/wsgi/routes/stats.py
@@ -38,6 +38,7 @@ def configure(bp, config, db):
         user_stats = []
         for case in db.campaigns.users(campaign['id']):
             user_stats.append(parse_user_data(case, config))
+        timeline_stats = db.campaigns.days(campaign['id'])
         return render_template(
             "stats_wiki_campaign.html",
             wiki=wiki,
@@ -45,6 +46,7 @@ def configure(bp, config, db):
             style_tags=style_tags,
             campaign=campaign,
             user_stats=user_stats,
+            timeline_stats=timeline_stats,
             maintenance_notice=build_maintenance_notice(request, config))
 
     return bp

--- a/wikilabels/wsgi/templates/stats_wiki_campaign.html
+++ b/wikilabels/wsgi/templates/stats_wiki_campaign.html
@@ -58,15 +58,22 @@ $( this ).append( fieldset.$element ) }) });
           <div class="lead">
                 <h2>Campaign "{{ campaign['name'] }}" in {{ wiki }}</h2>
                 <span class="campaign"><ul><li>Labels done: {{ campaign["stats"]["labels"] }}</li><li>Labels needed: {{ campaign["stats"]["tasks"] * campaign["labels_per_task"] }}</li><li>Unique labelers: {{ campaign["stats"]["coders"] }}</li></ul></span>
-                {% if user_stats is not none %}
+                {% if user_stats %}
                 <h3>Users contributing in this campaign</h3>
                 <table class="wikitable" style="margin: 1em;"><thead><tr><th>User id</th><th>User name</th><th>Labels added</th></tr></thead><tbody>
                 {% for row in user_stats %}
                 <tr><td>{{ row["user"] }}</td><td>{{ row["user_name"] | safe }}</td><td>{{ row["count"] }}</td><tr>
                 {% endfor %}
                 </tbody></table>
-                {% else %}
-                {%endif %}
+                {% endif %}
+                {% if timeline_stats %}
+                <h3>Labels added per day</h3>
+                <table class="wikitable" style="margin: 1em;"><thead><tr><th>Date</th><th>Labels added</th></tr></thead><tbody>
+                {% for row in timeline_stats %}
+                <tr><td>{{ row["day"] }}</td><td>{{ row["count"] }}</td><tr>
+                {% endfor %}
+                </tbody></table>
+                {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
This will show how many labels have been added per day in each campaign
This will be useful in case a campaign is stalled

Bug: T189954