### PR TITLE
Reverse order of campaign stats labeling per day

### DIFF
--- a/wikilabels/database/campaigns.py
+++ b/wikilabels/database/campaigns.py
@@ -213,7 +213,7 @@ class Campaigns(Collection):
                 JOIN workset ON workset_task.workset_id = workset.id
                 WHERE campaign_id = {0}
                 GROUP BY day
-                ORDER BY day;
+                ORDER BY day DESC;
             """.format(int(campaign_id)))
 
             return list(cursor)


### PR DESCRIPTION
This way, seeing if a campaign is stalled or not would be easier.