### PR TITLE
Display rendered HTML in iframe

### DIFF
--- a/forms/i18n/unsourced_statements/en.json
+++ b/forms/i18n/unsourced_statements/en.json
@@ -1,10 +1,10 @@
 {
-    "form-title": "Labeling Unsourced Statements",
-    "notes-label": "Why?",
-    "citation-label": "Should this statement have a citation?",
-    "citation-true-label": "yes",
-    "citation-false-label": "no",
-    "unsure-label": "unsure",
-    "citation-help": "If you were reading this sentence in a Wikipedia article, would you add a {{Citation needed}} tag?",
-    "reason-help": "Please give us the reason for your decision in a sentence or to."
+    "form-title":"Labeling Unsourced Statements",
+    "notes-label":"Why?",
+    "citation-label":"Should this statement have an inline citation?",
+    "citation-true-label":"Yes",
+    "citation-false-label":"No",
+    "unsure-label":"Unsure",
+    "citation-help":"If you were reading this sentence in a Wikipedia article, would you add a {{Citation needed}} tag?",
+    "reason-help":"Please give us the reason for your decision in a sentence or two."
 }

--- a/forms/i18n/unsourced_statements/fr.json
+++ b/forms/i18n/unsourced_statements/fr.json
@@ -1,0 +1,10 @@
+{
+    "form-title":"Etiquetage de phrases sans sources",
+    "notes-label":"Pourquoi?",
+    "citation-label":"Ce texte a-t-il besoin d'une référence?",
+    "citation-true-label":"Oui",
+    "citation-false-label":"Non",
+    "unsure-label":"Pas sûr?",
+    "citation-help":"Si vous lisiez cette phrase dans un article de Wikipedia, la marqueriez-vous avec {{référence nécessaire}}?",
+    "reason-help":"Veuillez expliquer brièvement la raison de votre choix."
+}

--- a/forms/i18n/unsourced_statements/it.json
+++ b/forms/i18n/unsourced_statements/it.json
@@ -1,0 +1,10 @@
+{
+    "form-title":"Annotazione di frasi senza fonti",
+    "notes-label":"Perché?",
+    "citation-label":"Pensi che questa affermazione debba essere supportata da una fonte?",
+    "citation-true-label":"Sì",
+    "citation-false-label":"No",
+    "unsure-label":"Incerto/a",
+    "citation-help":"Se leggessi questa frase in una voce di Wikipedia, la segnaleresti come {{Senza fonte}}?",
+    "reason-help":"Puoi indicare brevemente la ragione della tua risposta?"
+}

--- a/wikilabels/wsgi/static/css/views.css
+++ b/wikilabels/wsgi/static/css/views.css
@@ -78,6 +78,9 @@ This can be removed if this file is loaded using ResourceLoader and CSSJanus.
 .wikilabels-printable-page-as-of-revision iframe .wikibase-statementgrouplistview{
 	display: none;
 }
-.unsourced-statement {
-	background-color: #ff0;
+.wikilabels-rendered-html iframe {
+	border-width: 0;
+	min-width: 600px;
+	min-height: 400px;
+	width: 100%;
 }


### PR DESCRIPTION
This prevents CSS and other clashes with the host document.

Also, split the RenderedHTML view into two and extract unsourced
statements related code into the new view UnsourcedStatement.