### PR TITLE
Create MulitDiffToPrevious view for session labelling

### DIFF
--- a/config/98-database.yaml
+++ b/config/98-database.yaml
@@ -2,4 +2,4 @@
 # database used during development.
 database:
   user: wikilabels
-  password: wikilabels-admin
+  password: wikilabels

--- a/config/98-database.yaml
+++ b/config/98-database.yaml
@@ -2,4 +2,4 @@
 # database used during development.
 database:
   user: wikilabels
-  password: wikilabels
+  password: wikilabels-admin

--- a/wikilabels/wsgi/static/css/views.css
+++ b/wikilabels/wsgi/static/css/views.css
@@ -26,6 +26,12 @@ This can be removed if this file is loaded using ResourceLoader and CSSJanus.
 .mw-content-rtl .wikilabels-diff-to-previous > .error {
 	text-align: right;
 }
+
+.wikilabels-diff-to-previous > .section-header {
+	font-size: 150%;
+	margin-top: 0.5em;
+}
+
 .wikilabels-diff-to-previous > .title {
 	font-size: 150%;
 	margin-top: 1em;
@@ -33,6 +39,7 @@ This can be removed if this file is loaded using ResourceLoader and CSSJanus.
 .wikilabels-diff-to-previous > .description {
 	margin-top: 0.5em;
 }
+
 .wikilabels-diff-to-previous > .comment {
 	margin-top: 0.5em;
 	font-style: italic;

--- a/wikilabels/wsgi/static/js/wikiLabels/views.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/views.js
@@ -159,7 +159,7 @@
 			// console.log('revIdList is:', revIdList);
 			if ( jindex >= revIdList.length ) {
 				// We're done here
-				this.tasks[index].diffListComplete = true
+				this.tasks[index].diffListComplete = true;
 				// console.log("Finished callback is:", finishedCallback)
 				if (finishedCallback == 'preCache'){
 					this.preCacheDiffs(index+1)
@@ -213,7 +213,7 @@
 	};
 
 	MultiDiffToPrevious.prototype.present = function ( taskInfo ) {
-		console.log('Present called with taskInfo', taskInfo)
+		console.log('Present called with taskInfo', taskInfo);
 		if ( taskInfo.diffListComplete ) {
 			this.presentDiff( taskInfo.diffList );
 		} else {
@@ -226,10 +226,13 @@
 		// console.log('DiffList is:', diffList);
 		this.$element.empty();
 
+		sessionHeader =  $('<h2>').text('This session had '+ diffList.length +' revisions.').addClass('session-header'),
+        this.$element.append(sessionHeader);
+
 		for (d=0; d<diffList.length; d++) {
             //loop over diffs
             var diffLink, diff;
-            diff = diffList[d]
+            diff = diffList[d];
 
             // console.log("now appending for:", diff);
 			revisionHeader = $('<h3>').text('Revision number '+(d+1)).addClass('revision-header'),

--- a/wikilabels/wsgi/static/js/wikiLabels/views.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/views.js
@@ -183,7 +183,7 @@
 			query.fail( function () {
 				// Recurse!
 				// console.error( 'Failed to get', revId );
-				this.tasks[ index ].diffList[ jindex ] = { tableRows: '<tr><td colspan="2" class="diff-lineno">This revision, ' + revId + ', has been deleted from the database. Please label as damaging/badfaith.</td></tr>' };
+				this.tasks[ index ].diffList[ jindex ] = { tableRows: '<tr><td colspan="2" class="diff-lineno">This revision, ' + revId + ', has been deleted from the database. Please skip this task.</td></tr>' };
 				this.preCacheRevList( index, jindex + 1, revIdList, finishedCallback );
 			}.bind( this ) );
 		}

--- a/wikilabels/wsgi/static/js/wikiLabels/views.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/views.js
@@ -183,7 +183,7 @@
 			query.fail( function () {
 				// Recurse!
 				// console.error( 'Failed to get', revId );
-				this.tasks[ index ].diffList[ jindex ] = {tableRows: '<tr><td colspan="2" class="diff-lineno">This revision, ' + revId + ', has been deleted from the database. Please label as damaging/badfaith.</td></tr>'};
+				this.tasks[ index ].diffList[ jindex ] = { tableRows: '<tr><td colspan="2" class="diff-lineno">This revision, ' + revId + ', has been deleted from the database. Please label as damaging/badfaith.</td></tr>' };
 				this.preCacheRevList( index, jindex + 1, revIdList, finishedCallback );
 			}.bind( this ) );
 		}
@@ -224,11 +224,19 @@
 
 	MultiDiffToPrevious.prototype.presentDiff = function ( taskInfo ) {
 		var diffLink, diffList, diff, d, sessionHeader, revisionHeader, title, description,
-			comment, direction, diffTable, sessionHeaderText;
+			comment, direction, diffTable, sessionHeaderText, note, plural;
 		diffList = taskInfo.diffList;
 		this.$element.empty();
+		// display note from taskInfo if there is one
+		if ( taskInfo.data.data.note !== '' && !taskInfo.data.data.note !== undefined ) {
+			note = $( '<div>' ).addClass( 'note' );
+			// we expect note to be HTML
+			note.html( taskInfo.data.data.note );
+			this.$element.append( note );
+		}
 		// display header telling the user how many diffs are in here
-		sessionHeaderText = 'This session had ' + diffList.length + ' revision';
+		plural = diffList.length === 1 ? '' : 's';
+		sessionHeaderText = 'This session had ' + diffList.length + ' revision' + plural + '.';
 		sessionHeader = $( '<h2>' ).text( sessionHeaderText ).addClass( 'session-header' );
 		this.$element.append( sessionHeader );
 

--- a/wikilabels/wsgi/static/js/wikiLabels/views.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/views.js
@@ -144,7 +144,7 @@
 
 	MultiDiffToPrevious = function ( taskListData ) {
 		MultiDiffToPrevious.super.call( this, taskListData );
-		this.$element.addClass( WL.config.prefix + 'multi-diff-to-previous' );
+		this.$element.addClass( WL.config.prefix + 'diff-to-previous' );
 		console.log('initially this $element', this)
 	};
 	OO.inheritClass( MultiDiffToPrevious, View );
@@ -155,12 +155,12 @@
 	MultiDiffToPrevious.prototype.preCacheRevList = function (index, jindex, revIdList, finishedCallback) {
 			var query, revId;
 			jindex = jindex || 0;
-			console.log('jindex is:', jindex);
-			console.log('revIdList is:', revIdList);
+			// console.log('jindex is:', jindex);
+			// console.log('revIdList is:', revIdList);
 			if ( jindex >= revIdList.length ) {
 				// We're done here
 				this.tasks[index].diffListComplete = true
-				console.log("Finished callback is:", finishedCallback)
+				// console.log("Finished callback is:", finishedCallback)
 				if (finishedCallback == 'preCache'){
 					this.preCacheDiffs(index+1)
 				}
@@ -171,15 +171,15 @@
 			} else if ( this.tasks[index].diffList[jindex] !== undefined ) {
 				console.log('were in jindex recurse statement');
 				// Already cached this diff.  Recurse!
-				getRevId( jindex + 1 );
+                this.preCacheRevList(index, jindex + 1, revIdList, finishedCallback);
 			} else {
 				revId = revIdList[jindex].rev_id;
-				console.log('revId is : ', revId);
+				// console.log('revId is : ', revId);
 				query = WL.api.diffToPrevious(revId);
-				console.log('asked for query');
+				// console.log('asked for query');
 				query.done(function (diff) {
 					// Recurse!
-					console.log('pre-caching diff for ', diff.title);
+					// console.log('pre-caching diff for ', diff.title);
 					this.tasks[index].diffList[jindex] = diff;
 					this.preCacheRevList(index, jindex + 1, revIdList, finishedCallback);
 				}.bind(this));
@@ -194,20 +194,20 @@
 
 	MultiDiffToPrevious.prototype.preCacheDiffs = function ( index ) {
 		index = index || 0;
-		console.log('In precache diffs with index:', index);
-		console.log('Tasks are,:', this.tasks);
+		// console.log('In precache diffs with index:', index);
+		// console.log('Tasks are,:', this.tasks);
 		if ( index >= this.tasks.length ) {
 			// We're done here
 			return null;
 		} else if ( this.tasks[ index ].diffList !== undefined ) {
-			console.log('were in recurse statement');
+			// console.log('were in recurse statement');
 			// Already cached this diffList.  Recurse!
 			this.preCacheDiffs( index + 1 );
 		} else {
 			// We don't have the diffList.  Go get it.
 			this.tasks[index].diffList = [];
 			this.tasks[index].diffListComplete = false;
-			console.log('initialized difflist');
+			// console.log('initialized difflist');
 			this.preCacheRevList(index, 0, this.tasks[index].data.data, 'preCache');
 		};
 	};
@@ -223,7 +223,7 @@
 	};
 
 	MultiDiffToPrevious.prototype.presentDiff = function ( diffList ) {
-		console.log('DiffList is:', diffList);
+		// console.log('DiffList is:', diffList);
 		this.$element.empty();
 
 		for (d=0; d<diffList.length; d++) {
@@ -232,7 +232,7 @@
             diff = diffList[d]
 
             // console.log("now appending for:", diff);
-			sectionHeader = $('<h3>').text('Revision number'+d).addClass('section-header'),
+			revisionHeader = $('<h3>').text('Revision number '+(d+1)).addClass('revision-header'),
             title = WL.util.linkToTitle(diff.title).addClass('title'),
                 description = $('<div>').addClass('description'),
                 comment = $('<div>').addClass('comment'),
@@ -241,7 +241,7 @@
                     $('<table>').addClass('diff diff-contentalign-right') :
                     $('<table>').addClass('diff diff-contentalign-left'));
 
-            this.$element.append(sectionHeader);
+            this.$element.append(revisionHeader);
             this.$element.append(title);
 
             diffLink = WL.util.linkToDiff(diff.revId).prop('outerHTML');

--- a/wikilabels/wsgi/static/js/wikiLabels/views.js
+++ b/wikilabels/wsgi/static/js/wikiLabels/views.js
@@ -182,7 +182,8 @@
 			}.bind( this ) );
 			query.fail( function () {
 				// Recurse!
-				console.error( 'Failed to get', revId );
+				// console.error( 'Failed to get', revId );
+				this.tasks[ index ].diffList[ jindex ] = {tableRows: '<tr><td colspan="2" class="diff-lineno">This revision, ' + revId + ', has been deleted from the database. Please label as damaging/badfaith.</td></tr>'};
 				this.preCacheRevList( index, jindex + 1, revIdList, finishedCallback );
 			}.bind( this ) );
 		}
@@ -223,17 +224,11 @@
 
 	MultiDiffToPrevious.prototype.presentDiff = function ( taskInfo ) {
 		var diffLink, diffList, diff, d, sessionHeader, revisionHeader, title, description,
-			comment, direction, diffTable, firstDate, lastDate, sessionMinutes, sessionHeaderText;
+			comment, direction, diffTable, sessionHeaderText;
 		diffList = taskInfo.diffList;
 		this.$element.empty();
 		// display header telling the user how many diffs are in here
-		if ( taskInfo.data.data.timestamps.length <= 1 ) { sessionMinutes = -1; } else {
-			firstDate = taskInfo.data.data.timestamps[ 0 ];
-			lastDate = taskInfo.data.data.timestamps[ taskInfo.data.data.timestamps.length - 1 ];
-			sessionMinutes = Math.ceil( ( lastDate - firstDate ) / ( 1000 * 60 ) );
-		}
-		sessionHeaderText = sessionMinutes < 0 ? 'This session had just 1 revision' :
-			'This session had ' + diffList.length + ' revisions over ' + sessionMinutes + ' minutes.';
+		sessionHeaderText = 'This session had ' + diffList.length + ' revision';
 		sessionHeader = $( '<h2>' ).text( sessionHeaderText ).addClass( 'session-header' );
 		this.$element.append( sessionHeader );
 


### PR DESCRIPTION
# Overview
This PR introduces a new wikilabels campaign type "MultiDiffToPrevious" which can be used to label not just a single edit, but multiple edits, like a Session. Among other applications, the thought is that this label will be useful in creating a meta-classifier on top of ORES that can identify useful newcomers. My hypothesis is that it will be easier to see good-faith/damaging in a session than in a single edit.

# views.js
Most of the work is done in view.js. A new class is made called `MultiDiffToPrevious` which extends (not in the object-oriented definition of the word) `DiffToPrevious`. I rewrite the 3 main functions: `preCacheDiffs` and `present` and `presentDiff`. Instead of storing the diff data as `this.tasks[index].diff` we now have `this.tasks[index].diffList` to store all the diff's associated with one session. In addition I fixed a Don't Repeat Yourself style problem where if the diff wasn't precached yet, `present` uses `preCacheDiff`'s diff-getting mechanism instead of implementing it's own. 


# Campaign table sql
Campaign insert line necessary for testing:
` wikilabels new_campaign enwiki test_session_campaign damaging_and_goodfaith MultiDiffToPrevious 1 10`

# Example data 
DiffToPrevious stores it's task data as 
+ `{rev_id: xxxx}`
MultiDiffToPrevious borrows this format and stores its data as a list of singleton dictionaries
+ `[{rev_id: xxxx}, {rev_id: yyyy},  ...n-many... {rev_id: zzzz}]`

Example data to use for testing: [https://gist.github.com/notconfusing/908d7b1a077909ff84b61a0ef131ceea](https://gist.github.com/notconfusing/908d7b1a077909ff84b61a0ef131ceea)

Load with line
```wikilabels task_inserts [campaign_id_of_MultiDiffToPrevious] < example_sessions_enwiki_50users.json```